### PR TITLE
Install React@next for React Hooks APIs

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -59,10 +59,9 @@ const npms = [
   "yarn add --dev @babel/plugin-transform-runtime",
 
   // React.js
-  "yarn add react",
-  "yarn add react-dom",
-  "yarn add prop-types",
-  //  "yarn add --dev raf",
+  "yarn add react@next",
+  "yarn add react-dom@next",
+  "yarn add prop-types@next",
 
   // Flux
   "yarn add flux",


### PR DESCRIPTION
`npx starter-react-flux init` will install the `react@next` and `react-dom@next` to add capability to use React Hooks APIs.